### PR TITLE
Remove Elasticsearch integration and switch to MongoDB-only search

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,31 @@
+# Core
+PORT=3000
+MONGO_URI=
+SECRET_KEY=
+FRONTEND_URL=http://localhost:5173
+
+# Redis
+REDIS_URL=redis://localhost:6379
+REDIS_TTL_NOTES_LIST=180
+REDIS_TTL_NOTE_BY_ID=300
+REDIS_TTL_USER_NOTES=180
+REDIS_TTL_POPULAR_NOTES=120
+
+# RabbitMQ
+RABBITMQ_URL=amqp://localhost:5672
+RABBITMQ_EXCHANGE=peerlearn.events
+RABBITMQ_QUEUE=peerlearn.events.queue
+RABBITMQ_DLX=peerlearn.events.dlx
+RABBITMQ_DLQ=peerlearn.events.dlq
+RABBITMQ_MAX_RETRIES=3
+
+# Email (SMTP)
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+MAIL_FROM=no-reply@peerlearn.app
+
+# API
+API_RATE_LIMIT_MAX=100

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -1,0 +1,23 @@
+# PeerLearn Backend: Redis + RabbitMQ + MongoDB Search
+
+## Architecture
+- **API layer (Express)**: Handles synchronous user/note APIs.
+- **Redis cache-aside**: Used by note list, note-by-id, user notes, and popular notes.
+- **RabbitMQ event bus**: Domain events are published by API and consumed by worker for async notifications and points update.
+- **MongoDB search layer**: Regex-based notes search with pagination and date sorting.
+- **Fallback model**:
+  - Redis unavailable → direct MongoDB read/write.
+  - RabbitMQ unavailable → request still succeeds; async side effects are skipped with logs.
+
+## Event Flow
+1. API writes source of truth in MongoDB.
+2. API invalidates Redis keys.
+3. API publishes event (`USER_REGISTERED`, `NOTE_UPLOADED`, `NOTE_DELETED`, `NOTE_DOWNLOADED`).
+4. Worker consumes and applies async tasks:
+   - Sends emails.
+   - Updates points (`+10` upload, `-10` download).
+5. Idempotency uses processed-event Redis key `app:events:processed:{eventId}`.
+
+## Search Flow
+1. `GET /api/note/search?q=...` executes MongoDB regex query.
+2. Results are paginated and sorted by date.

--- a/server/cache/cache.utils.js
+++ b/server/cache/cache.utils.js
@@ -1,0 +1,90 @@
+import { connectRedis } from "../config/redis.js";
+
+const metrics = {
+  hit: 0,
+  miss: 0,
+  set: 0,
+  del: 0,
+};
+
+export const cacheMetrics = () => ({ ...metrics });
+
+export const getCache = async (key) => {
+  const client = await connectRedis();
+  if (!client) return null;
+
+  try {
+    const value = await client.get(key);
+    if (value) metrics.hit += 1;
+    else metrics.miss += 1;
+    return value ? JSON.parse(value) : null;
+  } catch (error) {
+    console.error("[cache] get failed", key, error.message);
+    return null;
+  }
+};
+
+export const setCache = async (key, payload, ttlSeconds = 300) => {
+  const client = await connectRedis();
+  if (!client) return false;
+
+  try {
+    await client.set(key, JSON.stringify(payload), "EX", ttlSeconds);
+    metrics.set += 1;
+    return true;
+  } catch (error) {
+    console.error("[cache] set failed", key, error.message);
+    return false;
+  }
+};
+
+export const setCacheIfAbsent = async (key, payload, ttlSeconds = 300) => {
+  const client = await connectRedis();
+  if (!client) return false;
+
+  try {
+    const result = await client.set(key, JSON.stringify(payload), "EX", ttlSeconds, "NX");
+    return result === "OK";
+  } catch (error) {
+    console.error("[cache] set nx failed", key, error.message);
+    return false;
+  }
+};
+
+export const deleteCache = async (key) => {
+  const client = await connectRedis();
+  if (!client) return false;
+
+  try {
+    await client.del(key);
+    metrics.del += 1;
+    return true;
+  } catch (error) {
+    console.error("[cache] delete failed", key, error.message);
+    return false;
+  }
+};
+
+export const invalidatePattern = async (pattern, batchSize = 200) => {
+  const client = await connectRedis();
+  if (!client) return 0;
+
+  try {
+    let cursor = "0";
+    let totalDeleted = 0;
+
+    do {
+      const [nextCursor, keys] = await client.scan(cursor, "MATCH", pattern, "COUNT", batchSize);
+      cursor = nextCursor;
+      if (keys.length) {
+        await client.unlink(...keys);
+        totalDeleted += keys.length;
+      }
+    } while (cursor !== "0");
+
+    return totalDeleted;
+  } catch (error) {
+    console.error("[cache] invalidatePattern failed", pattern, error.message);
+    return 0;
+  }
+};

--- a/server/config/rabbitmq.js
+++ b/server/config/rabbitmq.js
@@ -1,0 +1,37 @@
+import amqp from "amqplib";
+
+let connection;
+let channel;
+
+export const getRabbitConnection = async () => {
+  if (connection) return connection;
+
+  const url = process.env.RABBITMQ_URL;
+  if (!url) {
+    console.warn("[rabbitmq] RABBITMQ_URL missing. Queue features disabled.");
+    return null;
+  }
+
+  connection = await amqp.connect(url);
+  connection.on("error", (err) => {
+    console.error("[rabbitmq] connection error", err.message);
+    connection = null;
+    channel = null;
+  });
+
+  connection.on("close", () => {
+    console.warn("[rabbitmq] connection closed");
+    connection = null;
+    channel = null;
+  });
+
+  return connection;
+};
+
+export const getRabbitChannel = async () => {
+  if (channel) return channel;
+  const conn = await getRabbitConnection();
+  if (!conn) return null;
+  channel = await conn.createChannel();
+  return channel;
+};

--- a/server/config/redis.js
+++ b/server/config/redis.js
@@ -1,0 +1,45 @@
+import Redis from "ioredis";
+
+let redisClient;
+
+export const getRedisClient = () => {
+  if (redisClient) return redisClient;
+
+  const redisUrl = process.env.REDIS_URL;
+  if (!redisUrl) {
+    console.warn("[redis] REDIS_URL not configured. Redis features disabled.");
+    return null;
+  }
+
+  redisClient = new Redis(redisUrl, {
+    maxRetriesPerRequest: 2,
+    lazyConnect: true,
+    enableAutoPipelining: true,
+    retryStrategy(times) {
+      const delay = Math.min(times * 200, 5000);
+      return delay;
+    },
+  });
+
+  redisClient.on("connect", () => console.log("[redis] connected"));
+  redisClient.on("error", (err) => console.error("[redis] error", err.message));
+  redisClient.on("reconnecting", () => console.warn("[redis] reconnecting..."));
+
+  return redisClient;
+};
+
+export const connectRedis = async () => {
+  const client = getRedisClient();
+  if (!client) return null;
+
+  if (client.status !== "ready") {
+    try {
+      await client.connect();
+    } catch (error) {
+      console.error("[redis] connect failed", error.message);
+      return null;
+    }
+  }
+
+  return client;
+};

--- a/server/controllers/noteController.js
+++ b/server/controllers/noteController.js
@@ -1,54 +1,69 @@
+import fs from "fs";
+import crypto from "crypto";
+import mongoose from "mongoose";
 import noteModel from "../models/noteModel.js";
 import cloudinary from "../config/cloudinary.js";
 import userModel from "../models/userModel.js";
-import fs from 'fs'
-import crypto from "crypto"
+import { emitDomainEvent } from "../queues/producers/eventProducer.js";
+import {
+  getCachedNoteById,
+  getCachedNotesList,
+  getCachedPopularNotes,
+  getCachedUserNotes,
+  setCachedNoteById,
+  setCachedNotesList,
+  setCachedPopularNotes,
+  setCachedUserNotes,
+  invalidateNotesCache,
+  getPopularIds,
+} from "../services/notesCache.service.js";
+import { searchNotes } from "../search/notes.search.js";
+import { cacheMetrics } from "../cache/cache.utils.js";
+
+const NOTE_USER_POPULATE = { path: "user", select: "name email profileImg" };
 
 export const testNote = (req, res) => {
   res.send("Note routes is working");
 };
 
 const getFileHash = (filePath) => {
-    const fileBuffer = fs.readFileSync(filePath)
-    const hashSum = crypto.createHash('sha256')
-    hashSum.update(fileBuffer)
-    const hex = hashSum.digest('hex')
-    return hex;
-}
+  const fileBuffer = fs.readFileSync(filePath);
+  const hashSum = crypto.createHash("sha256");
+  hashSum.update(fileBuffer);
+  return hashSum.digest("hex");
+};
+
+const normalizePageLimit = (page, limit, maxLimit = 50) => {
+  const safePage = Math.max(Number(page) || 1, 1);
+  const safeLimit = Math.min(Math.max(Number(limit) || 20, 1), maxLimit);
+  return { safePage, safeLimit, skip: (safePage - 1) * safeLimit };
+};
 
 export const createNotes = async (req, res) => {
   try {
-    const { title, college, degree, semester, branch, subject } = req.body;
+    const { title, college, degree, semester, branch, subject, description = "", tags = "" } = req.body;
     const file = req.file;
 
-    if (!file) {
-      return res.json({ success: false, message: "No file provided" });
-    }
+    if (!file) return res.json({ success: false, message: "No file provided" });
 
     const hashcode = getFileHash(file.path);
-
-    const dupliacte = await noteModel.findOne({ hashcode });
-    if(dupliacte){
-       fs.unlinkSync(file.path);
-       res.json({success : false, message : "Duplicate document detected!!"})
+    const duplicate = await noteModel.findOne({ hashcode }).lean();
+    if (duplicate) {
+      fs.unlinkSync(file.path);
+      return res.json({ success: false, message: "Duplicate document detected!!" });
     }
 
     const result = await cloudinary.uploader.upload(file.path, {
-      resource_type: "auto", // auto detects image, raw, video, etc.
-      folder: "notes", // optional folder
-      access_mode: "public", // makes file publicly accessible
+      resource_type: "auto",
+      folder: "notes",
+      access_mode: "public",
       use_filename: true,
       unique_filename: false,
       format: "pdf",
     });
 
     const fileUrl = result.secure_url;
-
-    // Construct first page image URL for preview (assuming cloudinary supports this)
     const firstPageImageUrl = fileUrl.replace(".pdf", ".jpg") + "#page=1";
-    console.log("firstPageImageUrl", firstPageImageUrl);
-
-    const user = await userModel.findById(req.user.id);
 
     let note = await noteModel.create({
       title,
@@ -57,33 +72,126 @@ export const createNotes = async (req, res) => {
       semester,
       branch,
       subject,
+      description,
+      tags: Array.isArray(tags) ? tags : String(tags).split(",").map((t) => t.trim()).filter(Boolean),
       image: firstPageImageUrl,
       fileUrl,
       hashcode,
       user: req.user.id,
     });
 
-    note = await note.populate("user");
+    await userModel.findByIdAndUpdate(req.user.id, { $addToSet: { uploads: note._id } });
+    note = await note.populate(NOTE_USER_POPULATE);
 
-    user.uploads.push(note._id);
-    user.points += 10;
-    await user.save();
+    await invalidateNotesCache({ noteId: note._id, userId: req.user.id });
+    await setCachedNoteById(note._id, { success: true, note });
 
-    res.json({
-      success: true,
-      message: "Document submitted successfully",
-      note,
+
+    emitDomainEvent("NOTE_UPLOADED", {
+      userId: req.user.id,
+      email: note?.user?.email,
+      title: note.title,
+      noteId: String(note._id),
     });
+
+    return res.json({ success: true, message: "Document submitted successfully", note });
   } catch (error) {
     console.error("Error in createNotes:", error);
-    res.json({ success: false, message: error.message });
+    return res.json({ success: false, message: error.message });
   }
 };
 
 export const getNotes = async (req, res) => {
   try {
-    const notes = await noteModel.find().populate("user");
-    res.json({ success: true, notes });
+    const { safePage, safeLimit, skip } = normalizePageLimit(req.query.page, req.query.limit);
+    const cacheQuery = { page: safePage, limit: safeLimit };
+    const cached = await getCachedNotesList(cacheQuery);
+    if (cached) return res.json(cached);
+
+    const [notes, total] = await Promise.all([
+      noteModel.find().sort({ createdAt: -1 }).skip(skip).limit(safeLimit).populate(NOTE_USER_POPULATE).lean(),
+      noteModel.countDocuments(),
+    ]);
+
+    const payload = { success: true, notes, page: safePage, limit: safeLimit, total };
+    await setCachedNotesList(cacheQuery, payload);
+
+    return res.json(payload);
+  } catch (error) {
+    return res.json({ success: false, message: error.message });
+  }
+};
+
+export const getNoteById = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const cached = await getCachedNoteById(id);
+    if (cached) return res.json(cached);
+
+    const note = await noteModel.findById(id).populate(NOTE_USER_POPULATE).lean();
+    if (!note) return res.status(404).json({ success: false, message: "Note not found" });
+
+    const payload = { success: true, note };
+    await setCachedNoteById(id, payload);
+    return res.json(payload);
+  } catch (error) {
+    return res.json({ success: false, message: error.message });
+  }
+};
+
+export const getUserNotes = async (req, res) => {
+  try {
+    const { userId } = req.params;
+    const { safePage, safeLimit, skip } = normalizePageLimit(req.query.page, req.query.limit);
+
+    const cacheQuery = { userId, page: safePage, limit: safeLimit };
+    const cached = await getCachedUserNotes(cacheQuery);
+    if (cached) return res.json(cached);
+
+    const [notes, total] = await Promise.all([
+      noteModel.find({ user: userId }).sort({ createdAt: -1 }).skip(skip).limit(safeLimit).populate(NOTE_USER_POPULATE).lean(),
+      noteModel.countDocuments({ user: userId }),
+    ]);
+
+    const payload = { success: true, notes, page: safePage, limit: safeLimit, total };
+    await setCachedUserNotes(cacheQuery, payload);
+
+    return res.json(payload);
+  } catch (error) {
+    return res.json({ success: false, message: error.message });
+  }
+};
+
+export const getPopularNotes = async (req, res) => {
+  try {
+    const limit = Math.min(Math.max(Number(req.query.limit) || 10, 1), 50);
+    const cached = await getCachedPopularNotes(limit);
+    if (cached) return res.json(cached);
+
+    const popularIds = await getPopularIds(limit);
+    let notes;
+
+    if (popularIds.length) {
+      notes = await noteModel.find({ _id: { $in: popularIds } }).populate(NOTE_USER_POPULATE).lean();
+      const orderMap = new Map(popularIds.map((id, i) => [String(id), i]));
+      notes.sort((a, b) => orderMap.get(String(a._id)) - orderMap.get(String(b._id)));
+    } else {
+      notes = await noteModel.find().sort({ views: -1, createdAt: -1 }).limit(limit).populate(NOTE_USER_POPULATE).lean();
+    }
+
+    const payload = { success: true, notes };
+    await setCachedPopularNotes(limit, payload);
+    return res.json(payload);
+  } catch (error) {
+    return res.json({ success: false, message: error.message });
+  }
+};
+
+export const searchNotesHandler = async (req, res) => {
+  try {
+    const { q = "", page = 1, limit = 10, sort = "relevance" } = req.query;
+    const result = await searchNotes({ q, page, limit, sort });
+    return res.json(result);
   } catch (error) {
     return res.json({ success: false, message: error.message });
   }
@@ -94,71 +202,79 @@ export const handleEvent = async (req, res) => {
     const { id, event } = req.body;
     const { noteId } = req.params;
 
-    const note = await noteModel.findById(noteId).populate("user");
-
-    if (!note) {
-      return res.status(404).json({ success: false, message: "Note not found" });
-    }
+    const note = await noteModel.findById(noteId).populate(NOTE_USER_POPULATE);
+    if (!note) return res.status(404).json({ success: false, message: "Note not found" });
 
     const liked = note.like.includes(id);
     const disliked = note.dislike.includes(id);
 
     if (event === "like") {
-      if (liked) {
-        note.like.pull(id);
-      } else {
+      if (liked) note.like.pull(id);
+      else {
         note.like.push(id);
-        if (disliked) {
-          note.dislike.pull(id);
-        }
+        if (disliked) note.dislike.pull(id);
       }
-      
     } else if (event === "dislike") {
-      if (disliked) {
-        note.dislike.pull(id);
-      } else {
+      if (disliked) note.dislike.pull(id);
+      else {
         note.dislike.push(id);
-        if (liked) {
-          note.like.pull(id);
-        }
+        if (liked) note.like.pull(id);
       }
     }
 
     await note.save();
-    res.json({ success: true, message: "Successfully updated", note });
+    await invalidateNotesCache({ noteId });
+    return res.json({ success: true, message: "Successfully updated", note });
   } catch (error) {
-    res.json({ success: false, message: error.message });
+    return res.json({ success: false, message: error.message });
   }
 };
 
 export const temp = async (req, res) => {
-    const result = await noteModel.updateMany(
-        { hashCode: { $exists: false } },  // users without messages field
-        { $set: { heshCode: String } }
-      );
-    res.json({ success: true, message: "Updated successfully!", result });
+  const result = await noteModel.updateMany({ hashCode: { $exists: false } }, { $set: { heshCode: String } });
+  return res.json({ success: true, message: "Updated successfully!", result });
 };
 
 export const deleteNote = async (req, res) => {
+  const session = await mongoose.startSession();
+  session.startTransaction();
+
   try {
-    // console.log("hui")
     const { id } = req.params;
-    
-    const note = await noteModel.findByIdAndDelete(id);
-    
+    const note = await noteModel.findById(id).populate(NOTE_USER_POPULATE).session(session);
+    if (!note) {
+      await session.abortTransaction();
+      session.endSession();
+      return res.status(404).json({ success: false, message: "Note not found" });
+    }
 
+    await noteModel.deleteOne({ _id: id }, { session });
     await userModel.updateMany(
-        { $or: [{ 'uploads._id': id }, { 'downloads._id': id }] },
-        {
-          $pull: {
-            uploads: {_id : id},
-            downloads: {_id : id},
-          },
-        }
-      );
+      { $or: [{ uploads: id }, { downloads: id }] },
+      { $pull: { uploads: id, downloads: id } },
+      { session }
+    );
 
-    res.json({ success: true, message: "Notes deleted successfully" });
+    await session.commitTransaction();
+    session.endSession();
+
+    await invalidateNotesCache({ noteId: id, userId: note?.user?._id });
+
+    emitDomainEvent("NOTE_DELETED", {
+      userId: note?.user?._id,
+      email: note?.user?.email,
+      title: note?.title,
+      noteId: id,
+    });
+
+    return res.json({ success: true, message: "Notes deleted successfully" });
   } catch (error) {
-    res.json({success : false, message : error.message});
+    await session.abortTransaction();
+    session.endSession();
+    return res.json({ success: false, message: error.message });
   }
+};
+
+export const getCacheMetrics = async (req, res) => {
+  return res.json({ success: true, metrics: cacheMetrics() });
 };

--- a/server/controllers/userController.js
+++ b/server/controllers/userController.js
@@ -3,6 +3,9 @@ import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import cloudinary from "../config/cloudinary.js";
 import User from "../models/userModel.js";
+import noteModel from "../models/noteModel.js";
+import { emitDomainEvent } from "../queues/producers/eventProducer.js";
+import { bumpPopularScore, invalidateNotesCache } from "../services/notesCache.service.js";
 
 export const test = (req, res) => {
   return res.json({ message: "Note routes is working", id: req.user.id });
@@ -11,40 +14,26 @@ export const test = (req, res) => {
 export const login = async (req, res) => {
   const { email, password } = req.body;
   try {
-    const user = await userModel
-      .findOne({ email })
-      .populate("uploads")
-      .populate("downloads").populate('bookmarks');
+    const user = await userModel.findOne({ email }).populate("uploads").populate("downloads").populate("bookmarks");
     if (!user) {
-      return res.json({
-        success: false,
-        message: "User does not exist.",
-      });
+      return res.json({ success: false, message: "User does not exist." });
     }
     const match = await bcrypt.compare(password, user.password);
     if (!match) {
-      return res.json({
-        success: false,
-        message: "Invalid email or password.",
-      });
+      return res.json({ success: false, message: "Invalid email or password." });
     }
 
-    const token = jwt.sign({ id: user._id }, process.env.SECRET_KEY, {
-      expiresIn: "2d",
-    });
+    const token = jwt.sign({ id: user._id }, process.env.SECRET_KEY, { expiresIn: "2d" });
     res.cookie("token", token, {
       httpOnly: true,
-      secure: true, // Must be true in production (HTTPS)
-      sameSite: "None", // Required for cross-origin cookies
-      maxAge: 7 * 24 * 60 * 60 * 1000, // optional
+      secure: true,
+      sameSite: "None",
+      maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
     return res.json({ success: true, message: "LoggedIn successfully!", user });
   } catch (error) {
-    res.json({
-      success: false,
-      message: error.message,
-    });
+    res.json({ success: false, message: error.message });
   }
 };
 
@@ -52,34 +41,24 @@ export const register = async (req, res) => {
   const { name, email, password } = req.body;
   try {
     const user = await userModel.findOne({ email });
-    if (user) {
-      return res.json({ success: false, message: "User already exists." });
-    }
+    if (user) return res.json({ success: false, message: "User already exists." });
 
     const salt = await bcrypt.genSalt(10);
     const hashedPassword = await bcrypt.hash(password, salt);
 
-    const newUser = await userModel.create({
-      name,
-      email,
-      password: hashedPassword,
-    });
+    const newUser = await userModel.create({ name, email, password: hashedPassword });
 
-    const token = jwt.sign({ id: newUser._id }, process.env.SECRET_KEY, {
-      expiresIn: "2d",
-    });
+    const token = jwt.sign({ id: newUser._id }, process.env.SECRET_KEY, { expiresIn: "2d" });
     res.cookie("token", token, {
       httpOnly: true,
-      secure: true, // Must be true in production (HTTPS)
-      sameSite: "None", // Required for cross-origin cookies
-      maxAge: 7 * 24 * 60 * 60 * 1000, // optional
+      secure: true,
+      sameSite: "None",
+      maxAge: 7 * 24 * 60 * 60 * 1000,
     });
 
-    return res.json({
-      success: true,
-      message: "User created successfully!",
-      user: newUser,
-    });
+    emitDomainEvent("USER_REGISTERED", { userId: newUser._id, email: newUser.email, name: newUser.name });
+
+    return res.json({ success: true, message: "User created successfully!", user: newUser });
   } catch (error) {
     return res.json({ success: false, message: error.message });
   }
@@ -87,14 +66,9 @@ export const register = async (req, res) => {
 
 export const isAuthorised = async (req, res) => {
   try {
-    if (!req.user) {
-      return res.json({ success: false, message: "You are not authorised" });
-    }
-    const user = await userModel
-      .findById(req.user.id)
-      .select("-password")
-      .populate("uploads")
-      .populate("downloads").populate("bookmarks");
+    if (!req.user) return res.json({ success: false, message: "You are not authorised" });
+
+    const user = await userModel.findById(req.user.id).select("-password").populate("uploads").populate("downloads").populate("bookmarks");
     return res.json({ success: true, user });
   } catch (error) {
     return res.json({ success: false, message: error.message });
@@ -103,12 +77,7 @@ export const isAuthorised = async (req, res) => {
 
 export const logout = async (req, res) => {
   try {
-    res.clearCookie("token", {
-      httpOnly: true,
-      sameSite: "None", // Required for cross-site cookies
-      secure: true,
-    });
-    console.log("logging out");
+    res.clearCookie("token", { httpOnly: true, sameSite: "None", secure: true });
     res.json({ success: true, message: "Logout Successfully!" });
   } catch (error) {
     res.json({ success: false, message: error.message });
@@ -117,22 +86,31 @@ export const logout = async (req, res) => {
 
 export const downloadNote = async (req, res) => {
   try {
-    const user = await userModel.findById(req.user.id);
     const { id } = req.body;
-    console.log(id);
 
-    if (user.downloads.includes(id)) {
+    const updatedUser = await userModel.findOneAndUpdate(
+      { _id: req.user.id, downloads: { $ne: id } },
+      { $addToSet: { downloads: id } },
+      { new: true }
+    );
+
+    if (!updatedUser) {
       return res.json({ success: false, message: "Note already downloaded!" });
     }
 
-    user.downloads.push(id);
-    user.points -= 10;
-    await user.save();
-    return res.json({
-      success: true,
-      message: "Note downloaded successfully!",
-      user,
+    const note = await noteModel.findByIdAndUpdate(id, { $inc: { views: 1 } }, { new: true }).populate("user");
+
+    await bumpPopularScore(id, 1);
+    await invalidateNotesCache({ noteId: id, userId: req.user.id });
+
+    emitDomainEvent("NOTE_DOWNLOADED", {
+      userId: req.user.id,
+      email: updatedUser.email,
+      noteId: id,
+      noteTitle: note?.title,
     });
+
+    return res.json({ success: true, message: "Note downloaded successfully!", user: updatedUser });
   } catch (error) {
     return res.json({ success: false, message: error.message });
   }
@@ -142,20 +120,12 @@ export const bookmarkNote = async (req, res) => {
   try {
     const user = await userModel.findById(req.user.id);
     const { id } = req.body;
-    console.log("bookmark", id);
 
-    if (user.bookmarks.includes(id)) {
-      return res.json({ success: false, message: "Note already exists in bookmark!" });
-    }
+    if (user.bookmarks.includes(id)) return res.json({ success: false, message: "Note already exists in bookmark!" });
 
     user.bookmarks.push(id);
-    
     await user.save();
-    return res.json({
-      success: true,
-      message: "Note bookmarked successfully!",
-      user,
-    });
+    return res.json({ success: true, message: "Note bookmarked successfully!", user });
   } catch (error) {
     return res.json({ success: false, message: error.message });
   }
@@ -165,20 +135,12 @@ export const removeBookmark = async (req, res) => {
   try {
     const user = await userModel.findById(req.user.id);
     const { id } = req.body;
-    console.log(id);
 
-    if (!user.bookmarks.includes(id)) {
-      return res.json({ success: false, message: "Note does not exists in bookmark!" });
-    }
+    if (!user.bookmarks.includes(id)) return res.json({ success: false, message: "Note does not exists in bookmark!" });
 
     user.bookmarks.pull(id);
-    
     await user.save();
-    return res.json({
-      success: true,
-      message: "Note removed from bookmarked!",
-      user,
-    });
+    return res.json({ success: true, message: "Note removed from bookmarked!", user });
   } catch (error) {
     return res.json({ success: false, message: error.message });
   }
@@ -188,10 +150,8 @@ export const updateUser = async (req, res) => {
   try {
     const { name, email, degree, college, branch, semester } = req.body;
     const file = req.file;
-    console.log(file);
 
     let result = null;
-
     if (file) {
       result = await cloudinary.uploader.upload(file.path, {
         folder: "note",
@@ -200,26 +160,15 @@ export const updateUser = async (req, res) => {
       });
     }
 
-    const url = result?.secure_url;
-
-    console.log(url);
-
     const user = await userModel
       .findByIdAndUpdate(
         req.user.id,
-        {
-          name,
-          email,
-          degree,
-          college,
-          branch,
-          semester,
-          profileImg: url || "",
-        },
+        { name, email, degree, college, branch, semester, profileImg: result?.secure_url || "" },
         { new: true }
       )
       .populate("downloads")
-      .populate("uploads").populate("bookmarks");
+      .populate("uploads")
+      .populate("bookmarks");
 
     res.json({ success: true, message: "User updated successfully!", user });
   } catch (error) {
@@ -228,10 +177,7 @@ export const updateUser = async (req, res) => {
 };
 
 export const temp = async (req, res) => {
-  const result = await User.updateMany(
-    { messages: { $exists: false } }, // users without messages field
-    { $set: { messages: [] } }
-  );
+  const result = await User.updateMany({ messages: { $exists: false } }, { $set: { messages: [] } });
   res.json({ success: true, message: "Updated successfully!", result });
 };
 
@@ -241,15 +187,9 @@ export const addMsg = async (req, res) => {
 
   try {
     const user = await userModel.findById(userId);
-    messages.forEach((msg) => {
-      user.messages.push(msg);
-    });
+    messages.forEach((msg) => user.messages.push(msg));
     await user.save();
-    res.json({
-      success: true,
-      message: "Messages added successfully!",
-      messages: user.messages,
-    });
+    res.json({ success: true, message: "Messages added successfully!", messages: user.messages });
   } catch (error) {
     res.json({ success: false, message: error.message });
   }
@@ -267,15 +207,10 @@ export const clearMsg = async (req, res) => {
 };
 
 export const listUser = async (req, res) => {
-    try{
-      const users = await User.aggregate([
-        {$sort : {points : -1}},
-        {$project : { name : 1, points : 1}}
-      ]);
-      //console.log(users);
-      return res.json({ success : true, users});
-    }
-    catch(err) {
-      return res.json( { succes : false, message : "Internal Server Error!" } );
-    }
-}
+  try {
+    const users = await User.aggregate([{ $sort: { points: -1 } }, { $project: { name: 1, points: 1 } }]);
+    return res.json({ success: true, users });
+  } catch (err) {
+    return res.json({ succes: false, message: "Internal Server Error!" });
+  }
+};

--- a/server/middleware/cacheRoute.js
+++ b/server/middleware/cacheRoute.js
@@ -1,0 +1,23 @@
+import { getCache, setCache } from "../cache/cache.utils.js";
+
+export const cacheRoute = ({ keyBuilder, ttlSeconds = 120 } = {}) => {
+  return async (req, res, next) => {
+    if (!keyBuilder) return next();
+
+    const key = keyBuilder(req);
+    if (!key) return next();
+
+    const cached = await getCache(key);
+    if (cached) return res.json(cached);
+
+    const originalJson = res.json.bind(res);
+    res.json = (payload) => {
+      if (payload?.success) {
+        setCache(key, payload, ttlSeconds).catch(() => {});
+      }
+      return originalJson(payload);
+    };
+
+    next();
+  };
+};

--- a/server/models/noteModel.js
+++ b/server/models/noteModel.js
@@ -36,6 +36,16 @@ const noteSchema = new mongoose.Schema({
         type : String,
         required :  true,
     },
+    description : {
+        type : String,
+        default : ''
+    },
+
+    tags : {
+        type : [String],
+        default : []
+    },
+
     user : {
         type : mongoose.Schema.Types.ObjectId,
         ref : 'User',
@@ -63,6 +73,11 @@ const noteSchema = new mongoose.Schema({
     like: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
     dislike: [{ type: mongoose.Schema.Types.ObjectId, ref: 'User' }],
 },{ timestamps : true })
+
+noteSchema.index({ hashcode: 1 }, { unique: true, sparse: true });
+noteSchema.index({ user: 1, createdAt: -1 });
+noteSchema.index({ createdAt: -1 });
+noteSchema.index({ subject: 1, branch: 1 });
 
 const noteModel = mongoose.model("Note", noteSchema)
 export default noteModel

--- a/server/package.json
+++ b/server/package.json
@@ -21,6 +21,13 @@
     "path": "^0.12.7",
     "pdf-poppler": "^0.2.1",
     "pdf2pic": "^3.1.4",
-    "socket.io": "^4.8.1"
+    "socket.io": "^4.8.1",
+    "amqplib": "^0.10.5",
+    "ioredis": "^5.4.1",
+    "nodemailer": "^6.9.15"
+  },
+  "scripts": {
+    "start": "node server.js",
+    "worker": "node worker.js"
   }
 }

--- a/server/queues/consumers/eventConsumer.js
+++ b/server/queues/consumers/eventConsumer.js
@@ -1,0 +1,88 @@
+import { setupRabbitTopology, QUEUE } from "../../services/rabbitmq.service.js";
+import { sendEmail } from "../../services/email.service.js";
+import userModel from "../../models/userModel.js";
+import { cacheKeys } from "../../services/redis.service.js";
+import { setCacheIfAbsent } from "../../cache/cache.utils.js";
+
+const MAX_RETRIES = Number(process.env.RABBITMQ_MAX_RETRIES || 3);
+
+const tryClaimEvent = async (eventId) => {
+  if (!eventId) return true;
+  return setCacheIfAbsent(cacheKeys.processedEvent(eventId), { processed: true }, 24 * 60 * 60);
+};
+
+const handleEvent = async (event) => {
+  const { type, payload } = event;
+
+  if (type === "USER_REGISTERED" && payload.email) {
+    await sendEmail({
+      to: payload.email,
+      subject: "Welcome to PeerLearn",
+      text: `Hi ${payload.name || "Student"}, welcome to PeerLearn!`,
+    });
+    return;
+  }
+
+  if (type === "NOTE_UPLOADED") {
+    if (payload.userId) await userModel.findByIdAndUpdate(payload.userId, { $inc: { points: 10 } });
+    if (payload.email) {
+      await sendEmail({ to: payload.email, subject: "Note uploaded", text: `Your note "${payload.title}" was uploaded.` });
+    }
+    return;
+  }
+
+  if (type === "NOTE_DOWNLOADED") {
+    if (payload.userId) await userModel.findByIdAndUpdate(payload.userId, { $inc: { points: -10 } });
+    if (payload.email) {
+      await sendEmail({ to: payload.email, subject: "Note downloaded", text: `You downloaded a note and points were updated.` });
+    }
+    return;
+  }
+
+  if (type === "NOTE_DELETED" && payload.email) {
+    await sendEmail({ to: payload.email, subject: "Note deleted", text: `Your note "${payload.title}" was deleted.` });
+  }
+};
+
+export const startEventConsumer = async () => {
+  const channel = await setupRabbitTopology();
+  if (!channel) return;
+
+  channel.prefetch(10);
+
+  channel.consume(QUEUE, async (msg) => {
+    if (!msg) return;
+
+    const headers = msg.properties.headers || {};
+    const retryCount = Number(headers["x-retry-count"] || 0);
+
+    try {
+      const event = JSON.parse(msg.content.toString());
+      const eventId = event?.payload?.eventId || msg.properties.messageId;
+
+      const claimed = await tryClaimEvent(eventId);
+      if (!claimed) {
+        channel.ack(msg);
+        return;
+      }
+
+      await handleEvent(event);
+      channel.ack(msg);
+    } catch (error) {
+      console.error("[rabbitmq] consume error", error.message);
+      if (retryCount < MAX_RETRIES) {
+        channel.publish(msg.fields.exchange, msg.fields.routingKey, msg.content, {
+          persistent: true,
+          headers: { ...headers, "x-retry-count": retryCount + 1 },
+          messageId: msg.properties.messageId,
+          contentType: msg.properties.contentType,
+        });
+        channel.ack(msg);
+      } else {
+        channel.nack(msg, false, false);
+      }
+    }
+  });
+
+  console.log("[rabbitmq] consumer started");
+};

--- a/server/queues/producers/eventProducer.js
+++ b/server/queues/producers/eventProducer.js
@@ -1,0 +1,11 @@
+import crypto from "crypto";
+import { publishEvent } from "../../services/rabbitmq.service.js";
+
+export const emitDomainEvent = async (type, payload = {}) => {
+  const eventId = payload.eventId || crypto.randomUUID();
+  try {
+    await publishEvent({ type, payload: { ...payload, eventId } });
+  } catch (error) {
+    console.error("[rabbitmq] publish failed", type, error.message);
+  }
+};

--- a/server/routes/noteRoutes.js
+++ b/server/routes/noteRoutes.js
@@ -1,17 +1,44 @@
-import express from 'express';
-import { testNote, createNotes, getNotes, temp, handleEvent, deleteNote } from '../controllers/noteController.js';
-import upload from '../config/multer.js';
-import { authUser } from '../middleware/authUser.js';
+import express from "express";
+import {
+  testNote,
+  createNotes,
+  getNotes,
+  temp,
+  handleEvent,
+  deleteNote,
+  getNoteById,
+  getUserNotes,
+  getPopularNotes,
+  searchNotesHandler,
+  getCacheMetrics,
+} from "../controllers/noteController.js";
+import upload from "../config/multer.js";
+import { authUser } from "../middleware/authUser.js";
+import { cacheRoute } from "../middleware/cacheRoute.js";
 
 const noteRouter = express.Router();
 
-noteRouter.get('/test', testNote);
-noteRouter.post('/create-notes', upload.single('file'), authUser, createNotes);
-noteRouter.get('/get', getNotes);
-noteRouter.post('/:noteId', handleEvent);
-noteRouter.delete('/delete/:id', authUser, deleteNote);
-noteRouter.get('/temp', temp);
-
-
+noteRouter.get("/test", testNote);
+noteRouter.post("/create-notes", upload.single("file"), authUser, createNotes);
+noteRouter.get(
+  "/get",
+  cacheRoute({
+    keyBuilder: (req) => {
+      const page = Math.max(Number(req.query.page) || 1, 1);
+      const limit = Math.min(Math.max(Number(req.query.limit) || 20, 1), 50);
+      return `app:notes:list:page:${page}:limit:${limit}`;
+    },
+    ttlSeconds: Number(process.env.REDIS_TTL_NOTES_LIST || 180),
+  }),
+  getNotes
+);
+noteRouter.get("/popular", getPopularNotes);
+noteRouter.get("/search", searchNotesHandler);
+noteRouter.get("/cache-metrics", getCacheMetrics);
+noteRouter.get("/id/:id", getNoteById);
+noteRouter.get("/user/:userId", getUserNotes);
+noteRouter.post("/:noteId", handleEvent);
+noteRouter.delete("/delete/:id", authUser, deleteNote);
+noteRouter.get("/temp", temp);
 
 export default noteRouter;

--- a/server/search/notes.search.js
+++ b/server/search/notes.search.js
@@ -1,0 +1,31 @@
+import noteModel from "../models/noteModel.js";
+
+const NOTE_USER_POPULATE = { path: "user", select: "name email profileImg" };
+
+export const searchNotes = async ({ q = "", page = 1, limit = 10, sort = "relevance" }) => {
+  const safePage = Number(page) > 0 ? Number(page) : 1;
+  const safeLimit = Math.min(Number(limit) || 10, 50);
+  const query = String(q || "").trim();
+
+  const filter = query
+    ? {
+        $or: [
+          { title: { $regex: query, $options: "i" } },
+          { subject: { $regex: query, $options: "i" } },
+          { branch: { $regex: query, $options: "i" } },
+          { description: { $regex: query, $options: "i" } },
+          { tags: { $elemMatch: { $regex: query, $options: "i" } } },
+        ],
+      }
+    : {};
+
+  const sortObj = sort === "date" ? { createdAt: -1 } : { createdAt: -1 };
+  const skip = (safePage - 1) * safeLimit;
+
+  const [notes, total] = await Promise.all([
+    noteModel.find(filter).sort(sortObj).skip(skip).limit(safeLimit).populate(NOTE_USER_POPULATE).lean(),
+    noteModel.countDocuments(filter),
+  ]);
+
+  return { success: true, notes, page: safePage, limit: safeLimit, total, source: "mongodb" };
+};

--- a/server/server.js
+++ b/server/server.js
@@ -1,24 +1,25 @@
-import dotenv from 'dotenv';
-import http from 'http'
+import dotenv from "dotenv";
+import http from "http";
+import cookieParser from "cookie-parser";
+import express from "express";
+import rateLimit from "express-rate-limit";
+import connectDB from "./config/db.js";
+import userRouter from "./routes/userRoutes.js";
+import noteRouter from "./routes/noteRoutes.js";
+import cors from "cors";
+import apiRouter from "./routes/apiRoutes.js";
+import { Server } from "socket.io";
+import messageRouter from "./routes/messageRoutes.js";
+import { initSocket } from "./sockets/socket.js";
+import { connectRedis } from "./config/redis.js";
+import { setupRabbitTopology } from "./services/rabbitmq.service.js";
+
 dotenv.config();
 
-import cookieParser from 'cookie-parser';
-import express from 'express';
-import rateLimit from 'express-rate-limit';
-import connectDB from './config/db.js';
-import userRouter from './routes/userRoutes.js';
-import noteRouter from './routes/noteRoutes.js';
-import cors from 'cors';
-import apiRouter from './routes/apiRoutes.js';
-import { Server } from "socket.io";
-import messageRouter from "./routes/messageRoutes.js"
-import { initSocket } from './sockets/socket.js';
-
-const app = express()
-app.set('trust proxy', 1);
+const app = express();
+app.set("trust proxy", 1);
 const server = http.createServer(app);
 
-// ✅ Declare allowedOrigins at the top
 const allowedOrigins = [
   process.env.FRONTEND_URL,
   "http://localhost:5173",
@@ -27,32 +28,29 @@ const allowedOrigins = [
   "https://peer-learn-hcaoc1416-pankaj-kumars-projects-a2ff3a66.vercel.app",
 ];
 
-// ✅ Apply CORS correctly
-app.use(cors({
-  origin: function (origin, callback) {
-    if (!origin || allowedOrigins.includes(origin)) {
-      callback(null, true);
-    } else {
-      callback(new Error("Not allowed by CORS"));
-    }
-  },
-  credentials: true,
-}))
+app.use(
+  cors({
+    origin(origin, callback) {
+      if (!origin || allowedOrigins.includes(origin)) callback(null, true);
+      else callback(new Error("Not allowed by CORS"));
+    },
+    credentials: true,
+  })
+);
 
-connectDB()
+connectDB();
+connectRedis();
+setupRabbitTopology().catch((error) => console.error("[rabbitmq] topology setup failed", error.message));
 
-// ✅ Express parsers
-app.use(express.json())
-app.use(cookieParser())
+app.use(express.json());
+app.use(cookieParser());
 app.use(express.urlencoded({ extended: true }));
 
-// ✅ Log request origin
 app.use((req, res, next) => {
   console.log("🌐 Incoming request origin:", req.headers.origin);
   next();
 });
 
-// ✅ Apply socket.io with correct CORS
 const io = new Server(server, {
   cors: {
     origin: allowedOrigins,
@@ -60,27 +58,29 @@ const io = new Server(server, {
   },
 });
 
-initSocket(io)
+initSocket(io);
 
-// ✅ Define routes and rate limiting AFTER sockets initialized
-app.get('/', (req, res) => {
+app.get("/", (req, res) => {
   res.send("API is working");
-})
+});
 
-app.use('/api', rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
-  handler: (req, res) => {
-    console.warn(`[${new Date().toISOString()}] Rate limit exceeded for IP: ${req.ip}`);
-    res.status(429).json({ message: 'Too many requests, please try again later.' });
-  }
-}));
+app.use(
+  "/api",
+  rateLimit({
+    windowMs: 15 * 60 * 1000,
+    max: Number(process.env.API_RATE_LIMIT_MAX || 100),
+    handler: (req, res) => {
+      console.warn(`[${new Date().toISOString()}] Rate limit exceeded for IP: ${req.ip}`);
+      res.status(429).json({ message: "Too many requests, please try again later." });
+    },
+  })
+);
 
-app.use('/api/user', userRouter)
-app.use('/api/note', noteRouter)
-app.use('/api/chat', apiRouter)
-app.use('/api/messages', messageRouter)
+app.use("/api/user", userRouter);
+app.use("/api/note", noteRouter);
+app.use("/api/chat", apiRouter);
+app.use("/api/messages", messageRouter);
 
-server.listen(3000, () => {
-  console.log("Server is running on PORT 3000");
-})
+server.listen(process.env.PORT || 3000, () => {
+  console.log(`Server is running on PORT ${process.env.PORT || 3000}`);
+});

--- a/server/services/email.service.js
+++ b/server/services/email.service.js
@@ -1,0 +1,43 @@
+import nodemailer from "nodemailer";
+
+let transporter;
+
+const getTransporter = () => {
+  if (transporter) return transporter;
+
+  if (!process.env.SMTP_HOST) {
+    console.warn("[email] SMTP not configured. Emails are logged only.");
+    return null;
+  }
+
+  transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT || 587),
+    secure: process.env.SMTP_SECURE === "true",
+    auth: process.env.SMTP_USER
+      ? {
+          user: process.env.SMTP_USER,
+          pass: process.env.SMTP_PASS,
+        }
+      : undefined,
+  });
+
+  return transporter;
+};
+
+export const sendEmail = async ({ to, subject, text, html }) => {
+  const tx = getTransporter();
+
+  if (!tx) {
+    console.log("[email:mock]", { to, subject, text });
+    return { mocked: true };
+  }
+
+  return tx.sendMail({
+    from: process.env.MAIL_FROM || "no-reply@peerlearn.app",
+    to,
+    subject,
+    text,
+    html,
+  });
+};

--- a/server/services/notesCache.service.js
+++ b/server/services/notesCache.service.js
@@ -1,0 +1,45 @@
+import { getCache, setCache, deleteCache, invalidatePattern } from "../cache/cache.utils.js";
+import { cacheKeys, cacheTTL } from "./redis.service.js";
+import { connectRedis } from "../config/redis.js";
+
+export const getCachedNotesList = ({ page, limit }) => getCache(cacheKeys.notesList(page, limit));
+export const setCachedNotesList = ({ page, limit }, payload) => setCache(cacheKeys.notesList(page, limit), payload, cacheTTL.notesList);
+
+export const getCachedNoteById = (id) => getCache(cacheKeys.noteById(id));
+export const setCachedNoteById = (id, payload) => setCache(cacheKeys.noteById(id), payload, cacheTTL.noteById);
+
+export const getCachedUserNotes = ({ userId, page, limit }) => getCache(cacheKeys.userNotes(userId, page, limit));
+export const setCachedUserNotes = ({ userId, page, limit }, payload) => setCache(cacheKeys.userNotes(userId, page, limit), payload, cacheTTL.userNotes);
+
+export const getCachedPopularNotes = (limit) => getCache(cacheKeys.popularNotes(limit));
+export const setCachedPopularNotes = (limit, payload) => setCache(cacheKeys.popularNotes(limit), payload, cacheTTL.popularNotes);
+
+export const bumpPopularScore = async (noteId, by = 1) => {
+  const client = await connectRedis();
+  if (!client) return false;
+  try {
+    await client.zincrby("app:notes:download_rank", by, String(noteId));
+    return true;
+  } catch (error) {
+    console.error("[cache] bumpPopularScore failed", error.message);
+    return false;
+  }
+};
+
+export const getPopularIds = async (limit = 10) => {
+  const client = await connectRedis();
+  if (!client) return [];
+  try {
+    return await client.zrevrange("app:notes:download_rank", 0, limit - 1);
+  } catch (error) {
+    console.error("[cache] getPopularIds failed", error.message);
+    return [];
+  }
+};
+
+export const invalidateNotesCache = async ({ noteId, userId } = {}) => {
+  if (noteId) await deleteCache(cacheKeys.noteById(noteId));
+  if (userId) await invalidatePattern(`app:notes:user:${userId}:*`);
+  await invalidatePattern("app:notes:list:*");
+  await invalidatePattern("app:notes:popular:*");
+};

--- a/server/services/rabbitmq.service.js
+++ b/server/services/rabbitmq.service.js
@@ -1,0 +1,48 @@
+import crypto from "crypto";
+import { getRabbitChannel } from "../config/rabbitmq.js";
+
+export const EXCHANGE = process.env.RABBITMQ_EXCHANGE || "peerlearn.events";
+export const QUEUE = process.env.RABBITMQ_QUEUE || "peerlearn.events.queue";
+export const DLQ = process.env.RABBITMQ_DLQ || "peerlearn.events.dlq";
+export const DLX = process.env.RABBITMQ_DLX || "peerlearn.events.dlx";
+
+export const setupRabbitTopology = async () => {
+  const channel = await getRabbitChannel();
+  if (!channel) return null;
+
+  await channel.assertExchange(EXCHANGE, "topic", { durable: true });
+  await channel.assertExchange(DLX, "topic", { durable: true });
+
+  await channel.assertQueue(DLQ, { durable: true });
+  await channel.bindQueue(DLQ, DLX, "#");
+
+  await channel.assertQueue(QUEUE, {
+    durable: true,
+    deadLetterExchange: DLX,
+    deadLetterRoutingKey: "dead.letter",
+  });
+
+  await channel.bindQueue(QUEUE, EXCHANGE, "event.#");
+  return channel;
+};
+
+export const publishEvent = async ({ type, payload }) => {
+  const channel = await setupRabbitTopology();
+  if (!channel) return false;
+
+  const eventId = payload?.eventId || crypto.randomUUID();
+  const body = {
+    type,
+    payload: {
+      ...payload,
+      eventId,
+      emittedAt: new Date().toISOString(),
+    },
+  };
+
+  return channel.publish(EXCHANGE, `event.${type}`, Buffer.from(JSON.stringify(body)), {
+    persistent: true,
+    contentType: "application/json",
+    messageId: eventId,
+  });
+};

--- a/server/services/redis.service.js
+++ b/server/services/redis.service.js
@@ -1,0 +1,14 @@
+export const cacheKeys = {
+  notesList: (page = 1, limit = 20) => `app:notes:list:page:${page}:limit:${limit}`,
+  noteById: (id) => `app:notes:${id}`,
+  userNotes: (userId, page = 1, limit = 20) => `app:notes:user:${userId}:page:${page}:limit:${limit}`,
+  popularNotes: (limit = 10) => `app:notes:popular:limit:${limit}`,
+  processedEvent: (eventId) => `app:events:processed:${eventId}`,
+};
+
+export const cacheTTL = {
+  notesList: Number(process.env.REDIS_TTL_NOTES_LIST || 180),
+  noteById: Number(process.env.REDIS_TTL_NOTE_BY_ID || 300),
+  userNotes: Number(process.env.REDIS_TTL_USER_NOTES || 180),
+  popularNotes: Number(process.env.REDIS_TTL_POPULAR_NOTES || 120),
+};

--- a/server/worker.js
+++ b/server/worker.js
@@ -1,0 +1,17 @@
+import dotenv from "dotenv";
+import connectDB from "./config/db.js";
+import { connectRedis } from "./config/redis.js";
+import { startEventConsumer } from "./queues/consumers/eventConsumer.js";
+
+dotenv.config();
+
+const bootstrap = async () => {
+  await connectDB();
+  await connectRedis();
+  await startEventConsumer();
+};
+
+bootstrap().catch((error) => {
+  console.error("[worker] fatal error", error);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation
- Remove the Elasticsearch dependency and bootstrap complexity while preserving search functionality using MongoDB to simplify deployment and reduce infra requirements.
- Keep a reliable search endpoint and consistent behavior when ES is unavailable by making MongoDB the primary search implementation.

### Description
- Removed Elasticsearch modules and references by deleting `server/config/elastic.js` and `server/services/elastic.service.js` and removing the ES dependency from `server/package.json`.
- Replaced the search stack with a MongoDB-only implementation in `server/search/notes.search.js` (regex-based, paginated), and updated controllers and routes (`server/controllers/noteController.js`, `server/routes/noteRoutes.js`) to use the new search handler and endpoints such as `/api/note/search` and `/api/note/id/:id`.
- Added and integrated caching, Redis and RabbitMQ support and helpers (`server/cache/*`, `server/config/redis.js`, `server/config/rabbitmq.js`, `server/services/notesCache.service.js`, `server/services/rabbitmq.service.js`, `server/services/email.service.js`), plus event producer/consumer (`server/queues/producers/eventProducer.js`, `server/queues/consumers/eventConsumer.js`) and a worker bootstrap (`server/worker.js`) to preserve async side-effect behavior without ES.
- Updated server bootstrap (`server/server.js`), environment example (`server/.env.example`), and architecture docs (`server/ARCHITECTURE.md`) to remove ES initialization and reflect the MongoDB search flow and new cache/queue components.

### Testing
- Ran syntax checks with `node --check` on `server/server.js`, `server/controllers/noteController.js`, `server/search/notes.search.js`, and `server/controllers/userController.js`, and they all passed.
- Verified there are no remaining Elasticsearch references under `server/` using ripgrep (`rg -n "elastic|elasticsearch|ELASTIC_" server`) with no matches found.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c82c308cc83208b7cd016a7bbb514)